### PR TITLE
fix: :bug: XSS fix in raidpool and enforce stricter page_size bounds

### DIFF
--- a/modules/routes/api/market.py
+++ b/modules/routes/api/market.py
@@ -43,7 +43,7 @@ def get_market_item_info(item_name):
     """
     rarity = request.args.get('rarity', None, type=str)
     page = max(1, request.args.get('page', 1, type=int))
-    page_size = min(1000, request.args.get('page_size', 50, type=int))
+    page_size = max(1, min(1000, request.args.get('page_size', 50, type=int)))
 
     # Parse boolean parameters
     shiny = parse_boolean_param(request.args.get('shiny'), None)

--- a/modules/routes/web/templates/lootpool/raid_lootpool.html
+++ b/modules/routes/web/templates/lootpool/raid_lootpool.html
@@ -132,6 +132,7 @@
 
     <script type="module">
         import {render} from "https://esm.sh/minecraft-text";
+        const { default: DOMPurify } = await import('https://cdn.jsdelivr.net/npm/dompurify@3.0.8/dist/purify.min.js');
 
         // Initialize tooltips
         const tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))
@@ -148,7 +149,7 @@
                         const color = tooltipTriggerEl.getAttribute('data-gambit-color');
                         if (color) nameEl.style.color = color;
                     }
-                    if (descEl) descEl.innerHTML = render(descEl.textContent, "§").replace(/\n/g, "<br/>");
+                    if (descEl) descEl.innerHTML = DOMPurify.sanitize(render(descEl.textContent, "§").replace(/\n/g, "<br/>"));
                     tooltipInner.dataset.rendered = "true";
                 }
             });


### PR DESCRIPTION
Great project! However, there are some issues that could become problems later on if not resolved
I'll copy what I sent Sirop:
1) This isn't too big but setting page_size = 0 in api queries actually attempts to return every single item matching the query, as .limit(0) in pymongo results in no limit at all. I believe the issue is fixable by just checking if the number is between 1-1000 rather than just min(1000, page_size).

2) While testing locally, I noticed a potential XSS issue on the gambits page:
https://github.com/Wynnventory/WynnVentory_Web/blob/14f9f3bee6f9338a126cd72f69c7a285360f0bdf/modules/routes/web/templates/lootpool/raid_lootpool.html#L151 It seems that attacker injected content could be executed in the page for other users. Even though Jinja is safe, it renders characters like &gt; which renders strings that are html tags but are still text (which is ok), but then the render call on that text and subsequent .innerHTML set on line 151 re-interprets that text as html. In theory, this would allow an attacker to execute their own javascript on any visitor who opens the infected gambit tool tip. 

Addressed both issues with fixes, but for 2) an additional dependency of DOMPurify is added, so if that's unwanted that can be changed. 
